### PR TITLE
fix: online pilot list display and frosted-glass backdrop in production

### DIFF
--- a/src/components/about/AboutPanel.module.scss
+++ b/src/components/about/AboutPanel.module.scss
@@ -6,8 +6,8 @@
   display: grid;
   place-items: center;
   background: color-mix(in srgb, var(--sky-color-black) 40%, transparent);
-  backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
   z-index: 1001;
   padding: 24px;
 }

--- a/src/components/map/AirportInfoPanel.module.scss
+++ b/src/components/map/AirportInfoPanel.module.scss
@@ -7,8 +7,8 @@
   width: 380px;
   max-height: calc(100vh - 92px - var(--app-safe-top, env(safe-area-inset-top, 0px)) - 60px);
   background: color-mix(in srgb, var(--sky-bg-color-base) 75%, transparent);
-  backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
+  backdrop-filter: blur(20px);
   border-radius: 16px;
   border: 1px solid color-mix(in srgb, var(--sky-border-color) 60%, transparent);
   box-shadow: 
@@ -285,8 +285,8 @@
     border: none;
     border-top: 1px solid color-mix(in srgb, var(--sky-border-color) 60%, transparent);
     background: color-mix(in srgb, var(--sky-bg-color-base) 85%, transparent);
-    backdrop-filter: blur(20px);
     -webkit-backdrop-filter: blur(20px);
+    backdrop-filter: blur(20px);
     touch-action: none;
     transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1);
   }

--- a/src/components/map/ControllerInfoPanel.module.scss
+++ b/src/components/map/ControllerInfoPanel.module.scss
@@ -7,8 +7,8 @@
   width: 360px;
   max-height: calc(100vh - 92px - var(--app-safe-top, env(safe-area-inset-top, 0px)) - 60px);
   background: color-mix(in srgb, var(--sky-bg-color-base) 75%, transparent);
-  backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
+  backdrop-filter: blur(20px);
   border-radius: 16px;
   border: 1px solid color-mix(in srgb, var(--sky-border-color) 60%, transparent);
   box-shadow: 

--- a/src/components/map/PilotInfoPanel.module.scss
+++ b/src/components/map/PilotInfoPanel.module.scss
@@ -7,8 +7,8 @@
   width: 360px;
   max-height: calc(100vh - 92px - var(--app-safe-top, env(safe-area-inset-top, 0px)) - 60px);
   background: color-mix(in srgb, var(--sky-bg-color-base) 70%, transparent);
-  backdrop-filter: blur(22px) saturate(130%);
   -webkit-backdrop-filter: blur(22px) saturate(130%);
+  backdrop-filter: blur(22px) saturate(130%);
   border-radius: 16px;
   border: 1px solid color-mix(in srgb, var(--sky-border-color) 60%, transparent);
   box-shadow:
@@ -30,8 +30,8 @@
   box-shadow:
     inset 0 1px 0 color-mix(in srgb, var(--sky-color-white) 50%, transparent),
     0 16px 42px color-mix(in srgb, var(--sky-color-black) 20%, transparent);
-  backdrop-filter: blur(28px) saturate(165%);
   -webkit-backdrop-filter: blur(28px) saturate(165%);
+  backdrop-filter: blur(28px) saturate(165%);
 }
 
 .handleBar {
@@ -559,8 +559,8 @@
     border: none;
     border-top: 1px solid color-mix(in srgb, var(--sky-border-color) 60%, transparent);
     background: color-mix(in srgb, var(--sky-bg-color-base) 75%, transparent);
-    backdrop-filter: blur(20px);
     -webkit-backdrop-filter: blur(20px);
+    backdrop-filter: blur(20px);
     touch-action: none;
     transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1);
     /* Smooth spring-like transition */

--- a/src/components/statistics/PilotList.module.scss
+++ b/src/components/statistics/PilotList.module.scss
@@ -145,14 +145,14 @@
 .logoBox {
   grid-area: logo;
   position: relative;
-  width: 108px;
+  // width: 108px;
   height: 42px;
   display: flex;
   align-items: center;
   justify-content: center;
   overflow: hidden;
   border-radius: 10px;
-  background: color-mix(in srgb, var(--sky-bg-color-base) 74%, transparent);
+  // background: color-mix(in srgb, var(--sky-bg-color-base) 74%, transparent);
   align-self: center;
 }
 

--- a/src/components/statistics/PilotList.tsx
+++ b/src/components/statistics/PilotList.tsx
@@ -85,7 +85,7 @@ export default () => {
         <div className={styles.heading}>
           <div>
             <div className={styles.title}>在线机组</div>
-            <div className={styles.subtitle}>{list.length} 架在线 · 选择后回到地图查看详情</div>
+            <div className={styles.subtitle}>{list.length} 架在线</div>
           </div>
           <button className={styles.closeBtn} onClick={closeSheet} aria-label="关闭机组列表">
             <IconByName name="Close" />
@@ -106,7 +106,6 @@ export default () => {
               return (
                 <button key={p.session_id} className={styles.card} onClick={() => handlePilotClick(p)}>
                   <span className={styles.logoBox}>
-                    <span className={styles.logoFallback}>{airlineIcao || '---'}</span>
                     {airlineLogoUrl && (
                       <img
                         src={airlineLogoUrl}

--- a/src/themes/override.scss
+++ b/src/themes/override.scss
@@ -54,8 +54,8 @@ div[data-container-name] input, div[data-container-name] div {
     background: rgba(7, 18, 32, 0.64);
     border: 1px solid rgba(130, 180, 220, 0.16);
     box-shadow: 0 8px 22px rgba(0, 0, 0, 0.18), 0 0 0 1px rgba(130, 180, 220, 0.06);
-    backdrop-filter: blur(14px) saturate(140%);
     -webkit-backdrop-filter: blur(14px) saturate(140%);
+    backdrop-filter: blur(14px) saturate(140%);
   }
 
   .mapboxgl-ctrl-group button {


### PR DESCRIPTION
## Summary

- **Online pilot list display:** Clean up the online crew list panel so airline logos render correctly without a fixed logo box width, placeholder fallback text, or opaque background behind the logo area. Simplify the panel subtitle to show only the online count.
- **Frosted-glass backdrop in production:** Fix missing blur/backdrop on the pilot info panel (and other glass panels) in preview and production builds. Vite 8's CSS minifier drops the standard `backdrop-filter` when it is declared before `-webkit-backdrop-filter`; reorder declarations so both survive minification.

## Test plan

- [x] Open the online pilot list and confirm airline logos display cleanly without a boxed placeholder or `---` fallback text
- [x] Confirm the subtitle reads `{count} 架在线` only
- [x] Run `npm run build && npm run preview`, open a pilot info panel, and verify the frosted-glass backdrop blur is visible over the map
- [x] Spot-check other glass panels (controller info, airport info, about overlay, Mapbox controls in dark theme) for the same backdrop effect in production build