### PR TITLE
release: v0.5.2

### DIFF
--- a/src-tauri/gen/apple/app.xcodeproj/project.pbxproj
+++ b/src-tauri/gen/apple/app.xcodeproj/project.pbxproj
@@ -415,7 +415,7 @@
 					"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)",
 					"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)",
 				);
-				MARKETING_VERSION = 0.5.1;
+				MARKETING_VERSION = 0.5.2;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-Wl,-export_dynamic",
@@ -534,7 +534,7 @@
 					"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)",
 					"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)",
 				);
-				MARKETING_VERSION = 0.5.1;
+				MARKETING_VERSION = 0.5.2;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-Wl,-export_dynamic",
@@ -688,7 +688,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 0.5.1;
+				MARKETING_VERSION = 0.5.2;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -772,7 +772,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 0.5.1;
+				MARKETING_VERSION = 0.5.2;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = cn.skylineflyleague.map.beta.SyncSeekerWidgetExtension;

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.5.1</string>
+	<string>0.5.2</string>
 	<key>CFBundleVersion</key>
 	<string>101</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "SyncSeeker",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "identifier": "cn.skylineflyleague.map.beta",
   "build": {
     "frontendDist": "../dist",

--- a/src/configs/aboutStasticInfo.ts
+++ b/src/configs/aboutStasticInfo.ts
@@ -1,5 +1,5 @@
-const current_version = '0.5.1' // 不带v
-const release_date = '2026-06-27'
+const current_version = '0.5.2' // 不带v
+const release_date = '2026-07-11'
 
 export default {
     version_basic: {


### PR DESCRIPTION
## Summary

Version bump to **0.5.2** for the post-0.5.1 bugfix release.

## Test plan

- [x] Verify about page shows version 0.5.2
- [x] Verify Tauri / iOS bundle metadata reads 0.5.2